### PR TITLE
Attaching COM1 Serial

### DIFF
--- a/packer/vEOS-4-i386.json
+++ b/packer/vEOS-4-i386.json
@@ -54,7 +54,8 @@
               [ "modifyvm","{{.Name}}","--nicpromisc4","allow-all" ],
               [ "modifyvm","{{.Name}}","--nic5","intnet" ],
               [ "modifyvm","{{.Name}}","--intnet5","intnet{{.Name}}-5" ],
-              [ "modifyvm","{{.Name}}","--nicpromisc5","allow-all" ]
+              [ "modifyvm","{{.Name}}","--nicpromisc5","allow-all" ],
+              [ "modifyvm","{{.Name}}","--uart1", "0x3F8", "4", "--uartmode1","server", "\\\\.\\pipe\\vEOS-build-serial" ]
           ],
           "vboxmanage_post": [
               [ "modifyvm","{{.Name}}","--nic1","intnet" ],


### PR DESCRIPTION
Attaching COM1 Serial to be able building vagrant box with "Aboot-serial-*.iso" support.

Prevents restating of the virtualbox guest due to lack of any Serial ports when "Aboot-serial-*.iso" is used.