### PR TITLE
Serial should be present on guest but disconnected on host

### DIFF
--- a/packer/vEOS-4-i386.json
+++ b/packer/vEOS-4-i386.json
@@ -55,7 +55,7 @@
               [ "modifyvm","{{.Name}}","--nic5","intnet" ],
               [ "modifyvm","{{.Name}}","--intnet5","intnet{{.Name}}-5" ],
               [ "modifyvm","{{.Name}}","--nicpromisc5","allow-all" ],
-              [ "modifyvm","{{.Name}}","--uart1", "0x3F8", "4", "--uartmode1","server", "\\\\.\\pipe\\vEOS-build-serial" ]
+              [ "modifyvm","{{.Name}}","--uart1", "0x3F8", "4", "--uartmode1","disconnected" ]
           ],
           "vboxmanage_post": [
               [ "modifyvm","{{.Name}}","--nic1","intnet" ],


### PR DESCRIPTION
Fixes "pipe already in use" possible error with many VMs.

For proper build Serial should be present on guest Arista EOS(for Aboot-serial-*.iso) 
but disconnected at host on any host pipes to eliminate "pipe already in use" condition for host while running many VMs.

PS. Sorry for this regression. Checked that final vbox works fine with bow-tie topology example.