### PR TITLE
Remove Aboot.iso dependencies and updated versions to 4.21.0F

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # vagrant-veos
-Sample builder to create vagrant vEOS boxes from the Aboot.iso and vEOS-lab.iso files available to registered users at Arista software downloads.
+Sample builder to create vagrant vEOS boxes from the vEOS-lab.vmdk files available to registered users at Arista software downloads.
 
 ## Requirements
 
@@ -10,17 +10,16 @@ Sample builder to create vagrant vEOS boxes from the Aboot.iso and vEOS-lab.iso 
 
 ## Usage
 
-To build a vagrant box for Arista vEOS, first, you need to download 2 files from http://arista.com/ which requires registration.
+To build a vagrant box for Arista vEOS, first, you need to download a file from http://arista.com/ which requires registration.
 
 * Go to http://www.arista.com/
 * Login
 * Click on Software Downloads (bottom left)
-* Expand vEOS
-* Download Aboot-\*.iso (example: Aboot-veos-2.1.0.iso)
-* Download the vmdk for the desired vEOS version (example: vEOS-lab.4.15.0F.vmdk)
-* Save the 2 files to the packer/source/ directory as Aboot-vEOS.iso and vEOS.vmdk, respectively.
+* Expand EOS -> Actice Releases -> desired vEOS version -> vEOS-lab
+* Download the vmdk (example: vEOS-lab-4.21.0F.vmdk)
+* Save the file to the packer/source/ directory as vEOS.vmdk.
 * cd packer/
-* Build the basebox: ``packer build -var “version=4.15.0F” vEOS-4-i386.json``
+* Build the basebox: ``packer build -var "version=4.21.0F" vEOS-4-i386.json``
 * The completed basebox will be in ../builds/
 
 ## Booting your first vEOS box
@@ -31,14 +30,14 @@ bash shell, enter the EOS CLI, display the EOS version, exit, and destroy the
 VM.   You can customize how your vEOS node starts up by editing the Vagrantfile
 created by ``vagrant init``.
 
-    vagrant box add --name vEOS-lab-4.15.0F ../builds/vEOS-lab-4.15.0F-virtualbox.box
+    vagrant box add --name vEOS-lab-4.21.0F ../builds/vEOS-lab-4.21.0F-virtualbox.box
     vagrant box list
 
 Create a new environment and define which box you wish to use
 
     mkdir vEOS-test
     cd vEOS-test
-    vagrant init vEOS-lab-4.15.0F
+    vagrant init vEOS-lab-4.21.0F
 
 Optionally, add any additional configuration to your Vagrantfile, then ‘up’ your VM and login
 

--- a/examples/Testkitchen/veos.rb
+++ b/examples/Testkitchen/veos.rb
@@ -14,7 +14,7 @@
 #             OR per-VM using:
 #
 # platforms:
-#   - name: vEOS_4.15.3F
+#   - name: vEOS-lab-4.21.0F
 #     driver:
 #       vagrantfiles:
 #         - vagrantfiles/veos.rb

--- a/examples/bowtie/Vagrantfile
+++ b/examples/bowtie/Vagrantfile
@@ -18,7 +18,7 @@
 # | leaf03  |--------------| leaf04  |
 # +---------+e3          e3+---------+
 
-default_box = 'vEOS-4.17.2F'
+default_box = 'vEOS-lab-4.21.0F'
 
 Vagrant.configure(2) do |config|
   config.vm.define 'spine01' do |spine01|

--- a/examples/leaf-spine/Vagrantfile
+++ b/examples/leaf-spine/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure(2) do |config|
   config.vm.define 'spine00' do |spine00|
-    spine00.vm.box = 'vEOS-4.15.0F'
+    spine00.vm.box = 'vEOS-lab-4.21.0F'
     spine00.vm.network 'private_network',
                        virtualbox__intnet: 's00l01',
                        ip: '169.254.1.11', auto_config: false
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.define 'spine01' do |spine01|
-    spine01.vm.box = 'vEOS-4.15.0F'
+    spine01.vm.box = 'vEOS-lab-4.21.0F'
     spine01.vm.network 'private_network',
                        virtualbox__intnet: 's00l01',
                        ip: '169.254.1.11', auto_config: false

--- a/packer/source/vEOS.ovf
+++ b/packer/source/vEOS.ovf
@@ -19,7 +19,7 @@
       <Info>Meta-information about the installed software</Info>
       <Product>vEOS</Product>
       <Vendor>Arista Networks</Vendor>
-      <Version>4.14.5F</Version>
+      <Version>4.21.0F</Version>
       <VendorUrl>http://www.arista.com/</VendorUrl>
     </ProductSection>
     <OperatingSystemSection ovf:id="102">
@@ -59,14 +59,6 @@
         <rasd:ResourceType>5</rasd:ResourceType>
       </Item>
       <Item>
-        <rasd:Address>1</rasd:Address>
-        <rasd:Caption>ideController1</rasd:Caption>
-        <rasd:Description>IDE Controller</rasd:Description>
-        <rasd:InstanceID>4</rasd:InstanceID>
-        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
-        <rasd:ResourceType>5</rasd:ResourceType>
-      </Item>
-      <Item>
         <rasd:Address>0</rasd:Address>
         <rasd:Caption>usb</rasd:Caption>
         <rasd:Description>USB Controller</rasd:Description>
@@ -81,15 +73,6 @@
         <sasd:InstanceID>6</sasd:InstanceID>
         <sasd:Parent>3</sasd:Parent>
         <sasd:ResourceType>17</sasd:ResourceType>
-      </StorageItem>
-      <StorageItem>
-        <sasd:AddressOnParent>0</sasd:AddressOnParent>
-        <sasd:AutomaticAllocation>true</sasd:AutomaticAllocation>
-        <sasd:Caption>cdrom1</sasd:Caption>
-        <sasd:Description>CD-ROM Drive</sasd:Description>
-        <sasd:InstanceID>7</sasd:InstanceID>
-        <sasd:Parent>4</sasd:Parent>
-        <sasd:ResourceType>15</sasd:ResourceType>
       </StorageItem>
       <EthernetPortItem>
         <epasd:AutomaticAllocation>true</epasd:AutomaticAllocation>
@@ -250,9 +233,6 @@
         <StorageController name="IDE" type="PIIX4" PortCount="2" useHostIOCache="true" Bootable="true">
           <AttachedDevice type="HardDisk" port="0" device="0">
             <Image uuid="{7a06459a-1e3c-4185-a7bd-41740d30bda9}"/>
-          </AttachedDevice>
-          <AttachedDevice passthrough="false" type="DVD" port="1" device="0">
-            <Image uuid="{d9da859f-bd2e-492e-986f-cb38438a8d3b}"/>
           </AttachedDevice>
         </StorageController>
       </StorageControllers>

--- a/packer/source/vEOS.ovf
+++ b/packer/source/vEOS.ovf
@@ -36,11 +36,11 @@
         <vssd:VirtualSystemType>virtualbox-2.2</vssd:VirtualSystemType>
       </System>
       <Item>
-        <rasd:Caption>1 virtual CPU</rasd:Caption>
+        <rasd:Caption>2 virtual CPU</rasd:Caption>
         <rasd:Description>Number of virtual CPUs</rasd:Description>
         <rasd:InstanceID>1</rasd:InstanceID>
         <rasd:ResourceType>3</rasd:ResourceType>
-        <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+        <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
       </Item>
       <Item>
         <rasd:AllocationUnits>MegaBytes</rasd:AllocationUnits>
@@ -118,7 +118,7 @@
         <RemoteDisplay enabled="false" authType="Null" authTimeout="5000"/>
         <BIOS>
           <ACPI enabled="true"/>
-          <IOAPIC enabled="false"/>
+          <IOAPIC enabled="true"/>
           <Logo fadeIn="true" fadeOut="true" displayTime="0"/>
           <BootMenu mode="MessageAndMenu"/>
           <TimeOffset value="0"/>
@@ -176,7 +176,7 @@
             </DisabledModes>
             <InternalNetwork name="intnet"/>
           </Adapter>
-          <Adapter slot="5" enabled="false" MACAddress="080027260034" cable="true" speed="0" type="82540EM">
+          <Adapter slot="5" enabled="false" MACAddress="080027260034" cable="true" speed="0" promiscuousModePolicy="AllowAll" type="82540EM">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
@@ -184,7 +184,7 @@
               </NAT>
             </DisabledModes>
           </Adapter>
-          <Adapter slot="6" enabled="false" MACAddress="080027D41DCD" cable="true" speed="0" type="82540EM">
+          <Adapter slot="6" enabled="false" MACAddress="080027D41DCD" cable="true" speed="0" promiscuousModePolicy="AllowAll" type="82540EM">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>
@@ -192,7 +192,7 @@
               </NAT>
             </DisabledModes>
           </Adapter>
-          <Adapter slot="7" enabled="false" MACAddress="0800271B0B16" cable="true" speed="0" type="82540EM">
+          <Adapter slot="7" enabled="false" MACAddress="0800271B0B16" cable="true" speed="0" promiscuousModePolicy="AllowAll" type="82540EM">
             <DisabledModes>
               <NAT>
                 <DNS pass-domain="true" use-proxy="false" use-host-resolver="false"/>

--- a/packer/vEOS-4-i386.json
+++ b/packer/vEOS-4-i386.json
@@ -2,7 +2,8 @@
    "variables": {
       "version": "Unknown",
       "ram": "2048",
-      "boot_time":"2m30s"
+      "core": "2",
+      "boot_time":"3m00s"
    },
    "post-processors": [
      {
@@ -39,7 +40,7 @@
           "ssh_password": "admin",
           "vboxmanage": [
               [ "modifyvm","{{.Name}}","--memory","{{user `ram`}}" ],
-              [ "modifyvm","{{.Name}}","--cpus","1" ],
+              [ "modifyvm","{{.Name}}","--cpus","{{user `core`}}" ],
               [ "modifyvm","{{.Name}}","--nic1","nat" ],
               [ "modifyvm","{{.Name}}","--nicpromisc1","allow-all" ],
               [ "modifyvm","{{.Name}}","--nic2","intnet" ],
@@ -54,7 +55,7 @@
               [ "modifyvm","{{.Name}}","--nic5","intnet" ],
               [ "modifyvm","{{.Name}}","--intnet5","intnet{{.Name}}-5" ],
               [ "modifyvm","{{.Name}}","--nicpromisc5","allow-all" ],
-              [ "modifyvm","{{.Name}}","--uart1", "0x3F8", "4", "--uartmode1","server", "\\\\.\\pipe\\vEOS-build-serial" ]
+              [ "modifyvm","{{.Name}}","--uart1", "0x3F8", "4", "--uartmode1", "disconnected" ]
           ],
           "vboxmanage_post": [
               [ "modifyvm","{{.Name}}","--nic1","intnet" ],

--- a/packer/vEOS-4-i386.json
+++ b/packer/vEOS-4-i386.json
@@ -20,11 +20,11 @@
             "bash<enter><wait>",
             "sudo dhclient ma1<enter><wait>",
             "exit<enter><wait>",
-            "conf<enter>",
-            "aaa authorization exec default local<enter>",
-            "aaa root secret arista<enter>",
-            "username admin privilege 15 role network-admin secret admin<enter>",
-            "<exit>"
+            "conf<enter><wait>",
+            "aaa authorization exec default local<enter><wait>",
+            "aaa root secret arista<enter><wait>",
+            "username admin privilege 15 role network-admin secret admin<enter><wait>",
+            "exit<enter><wait>"
           ],
           "type": "virtualbox-ovf",
           "name" : "vEOS",
@@ -40,7 +40,6 @@
           "vboxmanage": [
               [ "modifyvm","{{.Name}}","--memory","{{user `ram`}}" ],
               [ "modifyvm","{{.Name}}","--cpus","1" ],
-              [ "storageattach","{{.Name}}","--storagectl","IDE","--port","1","--device","0","--type","dvddrive","--medium","source/Aboot-vEOS.iso" ],
               [ "modifyvm","{{.Name}}","--nic1","nat" ],
               [ "modifyvm","{{.Name}}","--nicpromisc1","allow-all" ],
               [ "modifyvm","{{.Name}}","--nic2","intnet" ],

--- a/packer/vagrantfile_templates/vEOS.rb
+++ b/packer/vagrantfile_templates/vEOS.rb
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  # config.vm.box = 'vEOS_4.14.4F'
+  # config.vm.box = 'vEOS-lab-4.21.0F'
 
   config.vm.provider 'virtualbox' do |_, override|
     # Disable synced folders


### PR DESCRIPTION
I had some trouble with vEOS-lab-4.20.1F-virtualbox.box from Arista download center, so I found this Git and build my own 4.21.0F without trouble. On this way, I didn't understand why we need the Aboot.iso, so I removed it and it's working.

To test the exsisting VagrantFiles, I updated the version number on all places to the same version, so we can do more copy/paste.

Thank you for this GIT and feel free to merge this PR.